### PR TITLE
Change the minimum CPU spec to run on AWS

### DIFF
--- a/data_preprocessing.yaml
+++ b/data_preprocessing.yaml
@@ -1,5 +1,5 @@
 resources:
-  cpus: 1
+  cpus: 1+
 
 envs:
   DATA_BUCKET_NAME: sky-demo-data-test

--- a/eval.yaml
+++ b/eval.yaml
@@ -1,5 +1,5 @@
 resources:
-  cpus: 1
+  cpus: 1+
   # Add GPUs here
 
 envs:

--- a/train.yaml
+++ b/train.yaml
@@ -1,5 +1,5 @@
 resources:
-  cpus: 1
+  cpus: 1+
   # Add GPUs here
 
 envs:


### PR DESCRIPTION
`cpu: 1` fails on AWS because no machines match that spec. Relaxing the requirements so the tasks can run on AWS without manually changing the config file.