### PR TITLE
Remove default value for DATA_BUCKET_NAME

### DIFF
--- a/data_preprocessing.yaml
+++ b/data_preprocessing.yaml
@@ -2,7 +2,7 @@ resources:
   cpus: 1+
 
 envs:
-  DATA_BUCKET_NAME: sky-demo-data-test
+  DATA_BUCKET_NAME:
   DATA_BUCKET_STORE_TYPE: s3
 
 file_mounts:

--- a/eval.yaml
+++ b/eval.yaml
@@ -3,7 +3,7 @@ resources:
   # Add GPUs here
 
 envs:
-  DATA_BUCKET_NAME: sky-demo-data-test
+  DATA_BUCKET_NAME:
   DATA_BUCKET_STORE_TYPE: s3
 
 file_mounts:

--- a/train.yaml
+++ b/train.yaml
@@ -3,7 +3,7 @@ resources:
   # Add GPUs here
 
 envs:
-  DATA_BUCKET_NAME: sky-demo-data-test
+  DATA_BUCKET_NAME:
   DATA_BUCKET_STORE_TYPE: s3
   NUM_EPOCHS: 2
 


### PR DESCRIPTION
Since bucket names must be globally unique, we shouldn't set a default value for the bucket since different users will try to create the same bucket and run into errors.

Instead, leaving it empty makes it a required env var that the user must set themselves; if they don't, it'll raise an error.